### PR TITLE
Pin GH actions

### DIFF
--- a/.github/workflows/action-docs.yml
+++ b/.github/workflows/action-docs.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
       - uses: ./
         id: app
         with:
@@ -17,16 +17,13 @@ jobs:
           app_base64_private_key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
           auth_type: installation
           org: philips-software
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           token: ${{ steps.app.outputs.token }}
-
-      - uses: npalm/action-docs-action@v1.3.0
-
+      - uses: npalm/action-docs-action@1ae674557116c26e42a4b278d8d49f0a25a4d670 # ratchet:npalm/action-docs-action@v1.3.0
       - name: Update readme in the repository
         if: github.event_name != 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # ratchet:stefanzweifel/git-auto-commit-action@v4.16.0
         with:
           commit_message: "chore(ci): Updating readme"
           file_pattern: README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:
           node-version: 16
 
@@ -24,7 +23,7 @@ jobs:
 
       - name: Update dist in the repository
         if: github.event_name != 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # ratchet:stefanzweifel/git-auto-commit-action@v4.16.0
         with:
           commit_message: 'chore(ci): Updating dist'
           file_pattern: dist/*
@@ -34,11 +33,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:
           node-version: 16
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Dependabot is also capable of pinning to future tag releases and will maintain the comment that describes the shasum.

https://github.com/dependabot/dependabot-core/issues/4691

## Gist used

I've used the following [Gist](https://gist.github.com/JeroenKnoops/7d77e0517e9a52be6a2d2fd91bfac9e1) to create this PR.